### PR TITLE
Fixed installation error TabError when using Python 3

### DIFF
--- a/pyRock/arduinoBoard.py
+++ b/pyRock/arduinoBoard.py
@@ -15,39 +15,39 @@ import pyRock.MCP230xx as MCP
 class ArduinoBoard:
 
     def __init__(self):
-	# initialize the Board:
-	# initialize the gpio's
+        # initialize the Board:
+        # initialize the gpio's
         ArduinoBoard.gpio = radxa_gpio()
-	# setup the dispatcher signals for button events
-	ArduinoBoard.SIGNAL_BUTTON_CHANGED  = 'button_changed'
-	ArduinoBoard.SIGNAL_BUTTON_PRESSED  = 'button_pressed'
-	ArduinoBoard.SIGNAL_BUTTON_RELEASED = 'button_released'
-	# define the button objects
-	self.button1 = self.Button(1, ArduinoBoard.gpio.j8p7)
-	self.button2 = self.Button(2, ArduinoBoard.gpio.j8p8)
-	self.button = []
-	self.button.append(self.button1)
-	self.button.append(self.button2)
-	# define  the led objects
-	self.led1 = self.Led(1, ArduinoBoard.gpio.j8p9)
-	self.led2 = self.Led(2, ArduinoBoard.gpio.j8p20)
-	self.led3 = self.Led(3, ArduinoBoard.gpio.j8p22)
-	self.led4 = self.Led(4, ArduinoBoard.gpio.j8p24)
-	self.led5 = self.Led(5, ArduinoBoard.gpio.j8p23)
-	self.led6 = self.Led(6, ArduinoBoard.gpio.j8p28)
-	self.led7 = self.Led(7, ArduinoBoard.gpio.j8p21)
-	self.led8 = self.Led(8, ArduinoBoard.gpio.j8p19)
-	self.led = []
-	self.led.append(self.led1)
-	self.led.append(self.led2)
-	self.led.append(self.led3)
-	self.led.append(self.led4)
-	self.led.append(self.led5)
-	self.led.append(self.led6)
-	self.led.append(self.led7)
-	self.led.append(self.led8)
-	# define the display object
-	self.display = self.Display()
+        # setup the dispatcher signals for button events
+        ArduinoBoard.SIGNAL_BUTTON_CHANGED  = 'button_changed'
+        ArduinoBoard.SIGNAL_BUTTON_PRESSED  = 'button_pressed'
+        ArduinoBoard.SIGNAL_BUTTON_RELEASED = 'button_released'
+        # define the button objects
+        self.button1 = self.Button(1, ArduinoBoard.gpio.j8p7)
+        self.button2 = self.Button(2, ArduinoBoard.gpio.j8p8)
+        self.button = []
+        self.button.append(self.button1)
+        self.button.append(self.button2)
+        # define  the led objects
+        self.led1 = self.Led(1, ArduinoBoard.gpio.j8p9)
+        self.led2 = self.Led(2, ArduinoBoard.gpio.j8p20)
+        self.led3 = self.Led(3, ArduinoBoard.gpio.j8p22)
+        self.led4 = self.Led(4, ArduinoBoard.gpio.j8p24)
+        self.led5 = self.Led(5, ArduinoBoard.gpio.j8p23)
+        self.led6 = self.Led(6, ArduinoBoard.gpio.j8p28)
+        self.led7 = self.Led(7, ArduinoBoard.gpio.j8p21)
+        self.led8 = self.Led(8, ArduinoBoard.gpio.j8p19)
+        self.led = []
+        self.led.append(self.led1)
+        self.led.append(self.led2)
+        self.led.append(self.led3)
+        self.led.append(self.led4)
+        self.led.append(self.led5)
+        self.led.append(self.led6)
+        self.led.append(self.led7)
+        self.led.append(self.led8)
+        # define the display object
+        self.display = self.Display()
 
     def printNumberWithLeds(self, number):
         if number > 255 :
@@ -55,15 +55,15 @@ class ArduinoBoard:
         for i in range(0, 8, 1):
             if (number / (1 << (7-i))) > 0:
                 self.led[i].setOn()
-	    else:
-		self.led[i].setOff()
+            else:
+                self.led[i].setOff()
             number = number % (1 << (7-i))
 
 
     class Display:
 
-	def __init__(self):
- 	    # define a lot of display constants
+        def __init__(self):
+             # define a lot of display constants
             # commands
             self.LCD_CLEARDISPLAY   = 0x01
             self.LCD_RETURNHOME     = 0x02
@@ -97,7 +97,7 @@ class ArduinoBoard:
             self.LCD_EUROPEAN_I     = 0x01
             self.LCD_RUSSIAN        = 0x02
             self.LCD_EUROPEAN_II    = 0x03
-	    # initialize gpio expander and used IO's
+            # initialize gpio expander and used IO's
             self.mcp      = MCP.MCP23017(0x20)
             self.RS_PIN   = self.mcp.GPA7
             self.RW_PIN   = self.mcp.GPA6
@@ -107,141 +107,141 @@ class ArduinoBoard:
             self.D6_PIN   = self.mcp.GPB6
             self.D7_PIN   = self.mcp.GPB7
             self.BUSY_PIN = self.D7_PIN
-	    # initialize display control, function and mode registers
-	    self.displaycontrol = self.LCD_DISPLAYON | self.LCD_CURSOROFF | self.LCD_BLINKOFF
-	    self.displayfunction = self.LCD_4BITMODE
-	    self.displaymode = self.LCD_ENTRYLEFT | self.LCD_ENTRYSHIFTDEC
-	    # Offset for up to 4 rows
-	    self.LCD_ROW_OFFSETS = (0x00, 0x40, 0x14, 0x54)
+            # initialize display control, function and mode registers
+            self.displaycontrol = self.LCD_DISPLAYON | self.LCD_CURSOROFF | self.LCD_BLINKOFF
+            self.displayfunction = self.LCD_4BITMODE
+            self.displaymode = self.LCD_ENTRYLEFT | self.LCD_ENTRYSHIFTDEC
+            # Offset for up to 4 rows
+            self.LCD_ROW_OFFSETS = (0x00, 0x40, 0x14, 0x54)
 
         def writeRegister(self, register, value):
             self.mcp._i2c.write8(register, value)
 
-	def readRegister(self, register):
-	    return self.mcp._i2c.readU8(register)
+        def readRegister(self, register):
+            return self.mcp._i2c.readU8(register)
 
-	def pulseEnable(self):
-	    self.gpioA = self.readRegister(self.mcp.GPIOA)
-	    # set EnablePin
-	    self.gpioA = self.gpioA | 0x20
-	    self.writeRegister(self.mcp.GPIOA, self.gpioA)
-	    self._delay_microseconds(50)
-	    # clear EnablePin
-	    self.gpioA = self.gpioA & 0xDF
-	    self.writeRegister(self.mcp.GPIOA, self.gpioA)
+        def pulseEnable(self):
+            self.gpioA = self.readRegister(self.mcp.GPIOA)
+            # set EnablePin
+            self.gpioA = self.gpioA | 0x20
+            self.writeRegister(self.mcp.GPIOA, self.gpioA)
+            self._delay_microseconds(50)
+            # clear EnablePin
+            self.gpioA = self.gpioA & 0xDF
+            self.writeRegister(self.mcp.GPIOA, self.gpioA)
 
-	def write4bits(self, value):
-	    regValue = value & 0x0F
-	    regValue = regValue << 4
-	    self.writeRegister(self.mcp.GPIOB, regValue)
-	    self._delay_microseconds(50)
-	    self.pulseEnable()
+        def write4bits(self, value):
+            regValue = value & 0x0F
+            regValue = regValue << 4
+            self.writeRegister(self.mcp.GPIOB, regValue)
+            self._delay_microseconds(50)
+            self.pulseEnable()
 
-	def send(self, value, mode):
-	    if mode > 0:
-		self.writeRegister(self.mcp.GPIOA, 0x80)
-	    else:
-		self.writeRegister(self.mcp.GPIOA, 0x00)
-	    self.write4bits(value>>4)
-	    self.write4bits(value)
+        def send(self, value, mode):
+            if mode > 0:
+                self.writeRegister(self.mcp.GPIOA, 0x80)
+            else:
+                self.writeRegister(self.mcp.GPIOA, 0x00)
+            self.write4bits(value>>4)
+            self.write4bits(value)
 
-	def command(self, value):
-	    self.send(value, 0)
-	    self.waitForReady()
+        def command(self, value):
+            self.send(value, 0)
+            self.waitForReady()
 
-	def write(self, value):
-	    self.send(value, 1)
-	    self.waitForReady()
+        def write(self, value):
+            self.send(value, 1)
+            self.waitForReady()
 
-	def waitForReady(self):
-	    self.busy = 1
-	    self.mcp.setup(self.BUSY_PIN, ArduinoBoard.gpio.INPUT)
-	    self.writeRegister(self.mcp.GPIOA, 0x40)
-	    while self.busy > 0:
-		self.writeRegister(self.mcp.GPIOA, 0x60)
-		self._delay_microseconds(10)
-		self.busy = self.mcp.input(self.BUSY_PIN)
-		self.writeRegister(self.mcp.GPIOA, 0x40)
-		self.pulseEnable()
-	    self.mcp.setup(self.BUSY_PIN, ArduinoBoard.gpio.OUTPUT)
-	    self.writeRegister(self.mcp.GPIOA, 0x00)
+        def waitForReady(self):
+            self.busy = 1
+            self.mcp.setup(self.BUSY_PIN, ArduinoBoard.gpio.INPUT)
+            self.writeRegister(self.mcp.GPIOA, 0x40)
+            while self.busy > 0:
+                self.writeRegister(self.mcp.GPIOA, 0x60)
+                self._delay_microseconds(10)
+                self.busy = self.mcp.input(self.BUSY_PIN)
+                self.writeRegister(self.mcp.GPIOA, 0x40)
+                self.pulseEnable()
+            self.mcp.setup(self.BUSY_PIN, ArduinoBoard.gpio.OUTPUT)
+            self.writeRegister(self.mcp.GPIOA, 0x00)
 
-	def _delay_microseconds(self, microseconds):
-	    end = time.time() + (microseconds/1000000.0)
-	    while time.time() < end:
-		pass
+        def _delay_microseconds(self, microseconds):
+            end = time.time() + (microseconds/1000000.0)
+            while time.time() < end:
+                pass
 
-	def message(self, text):
-	    for char in text:
-		if char == '\n':
-		    self.currline += 1
-		    # Move to left or right side depending on text direction
-		    col = 0 if self.displaymode & self.LCD_ENTRYLEFT > 0 else self.numcols - 1
-		    self.setCursor(col, self.currline)
-		else:
-		    self.write(ord(char))
+        def message(self, text):
+            for char in text:
+                if char == '\n':
+                    self.currline += 1
+                    # Move to left or right side depending on text direction
+                    col = 0 if self.displaymode & self.LCD_ENTRYLEFT > 0 else self.numcols - 1
+                    self.setCursor(col, self.currline)
+                else:
+                    self.write(ord(char))
 
-	def begin(self, cols, lines):
-	    self.numcols = cols
-	    self.numlines = lines
-	    self.currline = 0
-	    # define every IO of the mcp as output
-	    self.writeRegister(self.mcp.IODIRA, 0x00)
-	    self.writeRegister(self.mcp.IODIRB, 0x00)
-	    self.writeRegister(self.mcp.GPIOA, 0x00)
-	    self._delay_microseconds(50000)
-	    self.writeRegister(self.mcp.GPIOB, 0x00)
-	    # initialize display
-	    self.write4bits(0x03)
-	    self._delay_microseconds(5000)
-	    self.write4bits(0x08)
-	    self._delay_microseconds(5000)
-	    self.write4bits(0x02)
-	    self._delay_microseconds(5000)
-	    self.write4bits(0x02)
-	    self._delay_microseconds(5000)
-	    self.write4bits(0x08)
-	    self._delay_microseconds(5000)
-	    self.command(self.LCD_DISPLAYCONTROL | self.LCD_DISPLAYOFF)
-	    self._delay_microseconds(5000)
-	    self.command(self.LCD_CLEARDISPLAY)
-	    self._delay_microseconds(5000)
-	    self.command(self.LCD_ENTRYMODESET | self.displaymode)
-	    self._delay_microseconds(5000)
-	    self.command(self.LCD_RETURNHOME)
-	    self._delay_microseconds(5000)
-	    self.command(self.LCD_DISPLAYCONTROL | self.displaycontrol)
-
-	def setCursor(self, col, row):
-	    # Write to first line if out off bounds
-	    if row >= self.numlines:
-		row = 0
-	    # set location
-	    self.command(self.LCD_SETDDRAMADDR | (col + self.LCD_ROW_OFFSETS[row]))
-
-	def home(self):
-	    self.command(self.LCD_RETURNHOME)
-
-	def clear(self):
-	    self.command(self.LCD_CLEARDISPLAY)
-
-	def noDisplay(self):
-	    self.displaycontrol &= ~self.LCD_DISPLAYON
-	    self.command(self.LCD_DISPLAYCONTROL | self.displaycontrol)
-
-	def display(self):
-	    self.displaycontrol |= self.LCD_DISPLAYON
-	    self.command(self.LCD_DISPLAYCONTROL | self.displaycontrol)
-
-	def noCursor(self):
-	    self.displaycontrol &= ~self.LCD_CURSORON
-	    self.command(self.LCD_DISPLAYCONTROL | self.displaycontrol)
-
-	def cursor(self):
-	    self.displaycontrol |= self.LCD_CURSORON
+        def begin(self, cols, lines):
+            self.numcols = cols
+            self.numlines = lines
+            self.currline = 0
+            # define every IO of the mcp as output
+            self.writeRegister(self.mcp.IODIRA, 0x00)
+            self.writeRegister(self.mcp.IODIRB, 0x00)
+            self.writeRegister(self.mcp.GPIOA, 0x00)
+            self._delay_microseconds(50000)
+            self.writeRegister(self.mcp.GPIOB, 0x00)
+            # initialize display
+            self.write4bits(0x03)
+            self._delay_microseconds(5000)
+            self.write4bits(0x08)
+            self._delay_microseconds(5000)
+            self.write4bits(0x02)
+            self._delay_microseconds(5000)
+            self.write4bits(0x02)
+            self._delay_microseconds(5000)
+            self.write4bits(0x08)
+            self._delay_microseconds(5000)
+            self.command(self.LCD_DISPLAYCONTROL | self.LCD_DISPLAYOFF)
+            self._delay_microseconds(5000)
+            self.command(self.LCD_CLEARDISPLAY)
+            self._delay_microseconds(5000)
+            self.command(self.LCD_ENTRYMODESET | self.displaymode)
+            self._delay_microseconds(5000)
+            self.command(self.LCD_RETURNHOME)
+            self._delay_microseconds(5000)
             self.command(self.LCD_DISPLAYCONTROL | self.displaycontrol)
 
-	def noBlink(self):
+        def setCursor(self, col, row):
+            # Write to first line if out off bounds
+            if row >= self.numlines:
+                row = 0
+            # set location
+            self.command(self.LCD_SETDDRAMADDR | (col + self.LCD_ROW_OFFSETS[row]))
+
+        def home(self):
+            self.command(self.LCD_RETURNHOME)
+
+        def clear(self):
+            self.command(self.LCD_CLEARDISPLAY)
+
+        def noDisplay(self):
+            self.displaycontrol &= ~self.LCD_DISPLAYON
+            self.command(self.LCD_DISPLAYCONTROL | self.displaycontrol)
+
+        def display(self):
+            self.displaycontrol |= self.LCD_DISPLAYON
+            self.command(self.LCD_DISPLAYCONTROL | self.displaycontrol)
+
+        def noCursor(self):
+            self.displaycontrol &= ~self.LCD_CURSORON
+            self.command(self.LCD_DISPLAYCONTROL | self.displaycontrol)
+
+        def cursor(self):
+            self.displaycontrol |= self.LCD_CURSORON
+            self.command(self.LCD_DISPLAYCONTROL | self.displaycontrol)
+
+        def noBlink(self):
             self.displaycontrol &= ~self.LCD_BLINKON
             self.command(self.LCD_DISPLAYCONTROL | self.displaycontrol)
 
@@ -249,23 +249,23 @@ class ArduinoBoard:
             self.displaycontrol |= self.LCD_BLINKON
             self.command(self.LCD_DISPLAYCONTROL | self.displaycontrol)
 
-	def scrollDisplayLeft(self):
-	    self.command(self.LCD_CURSORSHIFT | self.LCD_DISPLAYMOVE | self.LCD_MOVELEFT )
+        def scrollDisplayLeft(self):
+            self.command(self.LCD_CURSORSHIFT | self.LCD_DISPLAYMOVE | self.LCD_MOVELEFT )
 
         def scrollDisplayRight(self):
             self.command(self.LCD_CURSORSHIFT | self.LCD_DISPLAYMOVE | self.LCD_MOVERIGHT )
 
-	def leftToRight(self):
-	    self.displaymode |= self.LCD_ENTRYLEFT
-	    self.command(self.LCD_ENTRYMODESET | self.displaymode)
+        def leftToRight(self):
+            self.displaymode |= self.LCD_ENTRYLEFT
+            self.command(self.LCD_ENTRYMODESET | self.displaymode)
 
         def rightToLeft(self):
             self.displaymode &= ~self.LCD_ENTRYLEFT
             self.command(self.LCD_ENTRYMODESET | self.displaymode)
 
-	def noAutoscroll(self):
-	    self.displaymode &= ~self.LCD_ENTRYSHIFTINC
-	    self.command(self.LCD_ENTRYMODESET | self.displaymode)
+        def noAutoscroll(self):
+            self.displaymode &= ~self.LCD_ENTRYSHIFTINC
+            self.command(self.LCD_ENTRYMODESET | self.displaymode)
 
         def autoscroll(self):
             self.displaymode |= self.LCD_ENTRYSHIFTINC
@@ -274,60 +274,60 @@ class ArduinoBoard:
 
     class Led:
 
-	def __init__(self, id, pin):
-	    self.id = id
-	    self.pin = pin
-	    self.isOn = False
+        def __init__(self, id, pin):
+            self.id = id
+            self.pin = pin
+            self.isOn = False
 
-	def setOn(self):
+        def setOn(self):
             ArduinoBoard.gpio.output(self.pin, ArduinoBoard.gpio.HIGH)
             self.isOn = True
 
-	def setOff(self):
-	    ArduinoBoard.gpio.output(self.pin, ArduinoBoard.gpio.LOW)
-	    self.isOn = False
+        def setOff(self):
+            ArduinoBoard.gpio.output(self.pin, ArduinoBoard.gpio.LOW)
+            self.isOn = False
 
-	def toggle(self):
-	    if self.isOn == True:
-		self.setOff()
-	    else:
-		self.setOn()
+        def toggle(self):
+            if self.isOn == True:
+                self.setOff()
+            else:
+                self.setOn()
 
 
     class Button:
 
-	def __init__(self, id, pin, logicLevel="activeLow"):
-	    self.id = id
-	    self.pin = pin
-	    self.logicLevel = logicLevel
-	    self.state = ArduinoBoard.gpio.input(self.pin)
-	    self.isPressed = self.evaluate(self.state, self.logicLevel)
+        def __init__(self, id, pin, logicLevel="activeLow"):
+            self.id = id
+            self.pin = pin
+            self.logicLevel = logicLevel
+            self.state = ArduinoBoard.gpio.input(self.pin)
+            self.isPressed = self.evaluate(self.state, self.logicLevel)
 
-	def check(self):
-	    #print "button %d is %d" % (self.id, ArduinoBoard.gpio.input(self.pin))
-	    if self.state != ArduinoBoard.gpio.input(self.pin):
-		self.state = ArduinoBoard.gpio.input(self.pin)
-		self.isPressed = self.evaluate(self.state, self.logicLevel)
-		dispatcher.send( signal=ArduinoBoard.SIGNAL_BUTTON_CHANGED, sender=self.id )
-		if self.isPressed == 0:
-		    dispatcher.send( signal=ArduinoBoard.SIGNAL_BUTTON_RELEASED, sender=self.id )
-		    #print "Button %d is released" % self.id
-		else:
-		    dispatcher.send( signal=ArduinoBoard.SIGNAL_BUTTON_PRESSED, sender=self.id )
-		    #print "Button %d is pressed" % self.id
+        def check(self):
+            #print "button %d is %d" % (self.id, ArduinoBoard.gpio.input(self.pin))
+            if self.state != ArduinoBoard.gpio.input(self.pin):
+                self.state = ArduinoBoard.gpio.input(self.pin)
+                self.isPressed = self.evaluate(self.state, self.logicLevel)
+                dispatcher.send( signal=ArduinoBoard.SIGNAL_BUTTON_CHANGED, sender=self.id )
+                if self.isPressed == 0:
+                    dispatcher.send( signal=ArduinoBoard.SIGNAL_BUTTON_RELEASED, sender=self.id )
+                    #print "Button %d is released" % self.id
+                else:
+                    dispatcher.send( signal=ArduinoBoard.SIGNAL_BUTTON_PRESSED, sender=self.id )
+                    #print "Button %d is pressed" % self.id
 
-	def evaluate(self, state, logicLevel):
-	    if logicLevel == "activeLow":
-		if state == 0:
-		    # if an activeLow button is LOW, it's pressed
-		    return 1
-		else:
-		    # if an activeLow button is HIGH, it's not pressed
-		    return 0
-	    else:
-		if state == 0:
-		    # if an activeHigh button is LOW, it's not pressed
-		    return 0
-		else:
-		    # if an activeHigh button is HIGH, its pressed
-		    return 1
+        def evaluate(self, state, logicLevel):
+            if logicLevel == "activeLow":
+                if state == 0:
+                    # if an activeLow button is LOW, it's pressed
+                    return 1
+                else:
+                    # if an activeLow button is HIGH, it's not pressed
+                    return 0
+            else:
+                if state == 0:
+                    # if an activeHigh button is LOW, it's not pressed
+                    return 0
+                else:
+                    # if an activeHigh button is HIGH, its pressed
+                    return 1


### PR DESCRIPTION
When installing on the Rock Pi S using Python 3, the following error was occurring:
```
running install_lib
copying build/lib.linux-aarch64-3.7/pyRock/arduinoBoard.py -> /usr/local/lib/python3.7/dist-packages/pyRock
byte-compiling /usr/local/lib/python3.7/dist-packages/pyRock/arduinoBoard.py to arduinoBoard.cpython-37.pyc
Sorry: TabError: inconsistent use of tabs and spaces in indentation (arduinoBoard.py, line 22)
running install_egg_info
```
This PR replaces all tabs in the file with spaces so it is consistent with Python PEP8 and fixes the error.